### PR TITLE
Bug fixed

### DIFF
--- a/Assets/Scripts/PerlerManager.cs
+++ b/Assets/Scripts/PerlerManager.cs
@@ -4,7 +4,7 @@ public class PerlerManager : MonoBehaviour
 {   
     public void ClearAllPerlers()
     {
-        GameObject[] beads = GameObject.FindGameObjectsWithTag("Perler");
+        GameObject[] beads = GameObject.FindGameObjectsWithTag("PerlerTag");
 
         foreach (GameObject bead in beads)
         {

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -99,7 +99,7 @@ public class Spawner : MonoBehaviour
 
         GameObject newBead = Instantiate(perlerBeadPrefab, spawnPosition, transform.rotation);
         ChangePerlerColor(newBead);
-        newBead.tag = PerlerTag; 
+        newBead.tag = "PerlerTag"; 
     }
 
     public void ToggleGrid()

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -4,7 +4,7 @@
 TagManager:
   serializedVersion: 3
   tags:
-  - Perler
+  - PerlerTag
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
This pull request updates the tag used for identifying perler beads in the project to improve consistency and avoid potential conflicts. The tag has been changed from "Perler" to "PerlerTag" across relevant files.

### Tag Update for Perler Beads:

* [`Assets/Scripts/PerlerManager.cs`](diffhunk://#diff-bbd5b1cb7c790fffde5d4bbf5e5386afed718fd5eac2028f20aa4d5a3b51db9eL7-R7): Updated the `ClearAllPerlers` method to use the new tag "PerlerTag" when finding game objects.
* [`Assets/Scripts/Spawner.cs`](diffhunk://#diff-b05bb7d40d86d7334856e97c15b2a94ff36819bf89d1b069bd1011f602263d80L102-R102): Updated the `CreatePerlerBead` method to assign the new tag "PerlerTag" to newly instantiated perler beads.
* [`ProjectSettings/TagManager.asset`](diffhunk://#diff-e69257521d1bbed0cad6e9152a3d72ed224166b4f2f60e872f8dc80bf1b4cdd2L7-R7): Replaced the "Perler" tag with "PerlerTag" in the project's tag manager settings.